### PR TITLE
MUF listing example change (rel. TMA-895)

### DIFF
--- a/11_working_with_data_permissions/02_checking_filters.asciidoc
+++ b/11_working_with_data_permissions/02_checking_filters.asciidoc
@@ -16,7 +16,18 @@ require 'gooddata'
 
 GoodData.with_connection do |c|
   GoodData.with_project('project_id') do |project|
-    project.data_permissions.pmap {|f| [f.related ? f.related.map! { |filter_user| filter_user.login }  : nil, f.pretty_expression]}
+    project.data_permissions.pmap {|filter| 
+      if !filter.related 
+      # filter is not assigned to any user, 'nil' is returned
+        [nil, filter.pretty_expression]
+      elsif filter.related.respond_to?(:login) 
+      # filter is assigned to single user, expect array of length 1
+        [[filter.related.login], filter.pretty_expression]
+      else
+      # filter is probably assigned to multiple users, array of logins is returned
+        [filter.related.map!(&:login), filter.pretty_expression] 
+      end
+    }
   end
 end
 

--- a/11_working_with_data_permissions/02_checking_filters.asciidoc
+++ b/11_working_with_data_permissions/02_checking_filters.asciidoc
@@ -16,7 +16,7 @@ require 'gooddata'
 
 GoodData.with_connection do |c|
   GoodData.with_project('project_id') do |project|
-    project.data_permissions.pmap {|f| [f.related.login, f.pretty_expression]}
+    project.data_permissions.pmap {|f| [f.related ? f.related.map! { |filter_user| filter_user.login }  : nil, f.pretty_expression]}
   end
 end
 


### PR DESCRIPTION
accounts for user filter object being assigned  to <nobody|single user|multiple users>, will return 'nil' or array reference as login list; related to TMA-895